### PR TITLE
Persist auth cookies to preserve 60‑day sessions

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,12 @@
 import { convexAuthNextjsMiddleware } from "@convex-dev/auth/nextjs/server";
 
-export default convexAuthNextjsMiddleware();
+// Persist auth cookies for 60 days so sessions survive browser restarts
+export default convexAuthNextjsMiddleware(undefined, {
+  cookieConfig: {
+    // maxAge is in seconds
+    maxAge: 60 * 60 * 24 * 60,
+  },
+});
 
 export const config = {
   // The following matcher runs middleware on all routes


### PR DESCRIPTION
## Summary
- configure convex auth middleware to issue cookies with a 60 day lifetime so sessions survive browser restarts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b42b2ca2788323a341b8c5ed6c0c94